### PR TITLE
Parannettu tiedoston avaamista

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ poetry install
 ```
 $ poetry shell
 ```
+
 ## Toiminnot komentorivillä
 ### Ohjelman suorittaminen
 Ohjelman pystyy suorittamaan komennolla:

--- a/src/repositories/citation_repository.py
+++ b/src/repositories/citation_repository.py
@@ -46,7 +46,6 @@ class CitationRepository:
                         'publisher': row[3]})
 
         name = input("Name for bib-file: ")
-        file = open(str(name)+'.bib', 'w')
 
         book_bib = ""
         i = 123123
@@ -57,8 +56,8 @@ class CitationRepository:
             tag = str.lower(str.replace(book["title"], " ", "")) + str(book["year"]) + str(i)
             book_bib = book_bib + f" @book{brl}{tag},\n title = '{book['title']}', \n author = '{book['author']}', \n year = '{book['year']}', \n publisher = '{book['publisher']}',\n{brr} \n\n"
             i = i + 1
-        file.write(book_bib)
-        file.close()
+        with open(str(name)+'.bib', 'w') as file:
+            file.write(book_bib)
 
 
 citation_repository = CitationRepository(get_database_connection())


### PR DESCRIPTION
Muutin `citation_repository.py`-tiedostoa siten, että tiedosto avataan `with`-avainsanalla. Tällöin sitä ei tarvitse erikseen sulkea.