### PR TITLE
Muuta CitationServices-luokassa muuttujan nimi

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ $ python3 index.py
 ### **Definition of done**
 
 Task on ohjelmoitu, testaus automatisoitu, dokumentoitu backlogille ja integroitu muuhun ohjelmistoon. Task on valmis, kun sen testikattavuus on 70%. Taskit on yksikkötestattu ja koodi ei sisällä Pylint-virheitä.
+
+

--- a/src/services/citation_service.py
+++ b/src/services/citation_service.py
@@ -15,8 +15,8 @@ class CitationServices:
         return self._citation_repository.show_books()
 
     def delete_book(self, title):
-        book = self._citation_repository.delete_book(title)
-        return book
+        deleted = self._citation_repository.delete_book(title)
+        return deleted
 
     def delete_all(self):
         delete = self._citation_repository.delete_all_books()


### PR DESCRIPTION
Muuta CitationServices-luokan delete_book-metodin muuttujan nimi book -> deleted. Muuttuja erottuisi muista samoin nimetyistä ja kuvaisi tarkemmin metodin toimintaa. 